### PR TITLE
Improving class namespace and PHPUnit fixtures

### DIFF
--- a/tests/Rules/DefaultRuleTest.php
+++ b/tests/Rules/DefaultRuleTest.php
@@ -12,7 +12,7 @@ class DefaultRuleTest extends TestCase
 {
     protected $context;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->context = new Context([

--- a/tests/Tools/HelpersTest.php
+++ b/tests/Tools/HelpersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Luur\Validator\Tools\Tests;
+namespace Luur\Validator\Tests\Tools;
 
 use Luur\Validator\Tools\Helpers;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
# Changed log

- Changing into the `Luur\Validator\Tests\Tools` namespace.
- According to the official [PHPUnit doc](https://phpunit.de/manual/5.7/en/fixtures.html), it should be the `protected function setUp` method.